### PR TITLE
Improved usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,8 @@ call glaive#Install()
 
 " Add helloworld to the runtime path.  (Normally this would be done with another
 " Bundle command, but helloworld doesn't have a repository of its own.)
-let s:path = maktaba#path#Join([
-    \ maktaba#rtp#LeafDirs()['maktaba'],
-    \ 'examples/helloworld'])
-call maktaba#plugin#Install(s:path)
+call maktaba#plugin#Install(maktaba#path#Join([maktaba#Maktaba().location,
+    \ 'examples', 'helloworld']))
 
 " Configure helloworld using glaive.
 Glaive helloworld plugin[mappings] name='Bram'


### PR DESCRIPTION
Glaive still needed a usage example, but the one I added previously left
a lot to be desired.

The new example uses helloworld, which everyone has by default, instead
of getting them to install my plugin.  :-)  It also omits the lengthy
exposition on the distinction between rtp-adding and installing, since
after PR1 gets committed, Glaive users won't need to care about that.
Best of all, it's a fully working example.
