### PR TITLE
Let Glaive use the canonical name to configure autoinstalled plugins

### DIFF
--- a/autoload/glaive.vim
+++ b/autoload/glaive.vim
@@ -64,7 +64,7 @@ function! glaive#GetPlugin(plugin) abort
     return maktaba#plugin#Get(a:plugin)
   catch /ERROR(NotFound):/
   endtry
-  
+
   " Get the maktaba plugin object for a plugin already on the runtimepath.
   " If the plugin was installed with a plugin manager like pathogen or vundle,
   " then it's possible that it's on the runtimepath but hasn't been "Installed"

--- a/doc/glaive.txt
+++ b/doc/glaive.txt
@@ -26,6 +26,24 @@ plugins in particular are encouraged to do so.
 COMMANDS                                                     *glaive-commands*
 
 :Glaive {plugin} [operation...]                                      *:Glaive*
+
+  {plugin} should be the canonical name for the plugin; see
+  |maktaba#plugin#CanonicalName|.  Actually, anything which evaluates to the
+  canonical name will work just as well; if you simply supply the path name of
+  the plugin, it will still work.
+
+  For instance, a plugin stored in a "my-plugin" folder can be configured with
+  any of the following forms:
+>
+    " Canonical name (preferred).
+    :Glaive my_plugin flag
+    " Folder name.
+    :Glaive my-plugin flag
+    " Something weird which evaluates to the canonical name (valid, but
+    " not recommended).
+    :Glaive my!plugin flag
+<
+
   Each [operation] may be in any of the following forms. They should be
   separated by whitespace. The syntax for updating settings is as follows:
 

--- a/plugin/commands.vim
+++ b/plugin/commands.vim
@@ -38,9 +38,9 @@ endfunction
 " @usage plugin [operation...]
 "
 " {plugin} should be the canonical name for the plugin; see
-" @function(maktaba#plugin#CanonicalName).  Actually, anything which
-" evaluates to the canonical name will work just as well; if you simply
-" supply the path name of the plugin, it will still work.
+" |maktaba#plugin#CanonicalName|.  Actually, anything which evaluates to the
+" canonical name will work just as well; if you simply supply the path name of
+" the plugin, it will still work.
 "
 " For instance, a plugin stored in a "my-plugin" folder can be
 " configured with any of the following forms:


### PR DESCRIPTION
This makes its behaviour consistent with pre-installed plugins.  It lets us configure a plugin at `my-plugin/` using

``` vim
Glaive my_plugin flag
```

instead of

``` vim
Glaive my-plugin flag
```

It is somewhat less efficient, since one has to call `maktaba#plugin#CanonicalName` on O(N) elements (N is the size of `maktaba#rtp#LeafDirs()`) every time Glaive configures a plugin.  So, O(NG) calls of `CanonicalName()` with G Glaive plugins.  We _might_ want to consider making the keys of `maktaba#rtp#LeafDirs()` be the canonical names, rather than the path names; this seems somewhat natural, and would take us back to O(N).  Then again, we might not.  (Not to mention, I think that would technically force us to version 2.x, since it's backwards-incompatible.  Yikes!)

At any rate, I think this is more correct and it probably justifies a small performance hit.  (Although I admit I haven't attempted to measure such a hit.)

---

Oh, and I also documented the rules for the plugin name in the `:Glaive` command.
