### PR TITLE
Add "name" to addon-info.json

### DIFF
--- a/addon-info.json
+++ b/addon-info.json
@@ -1,4 +1,5 @@
 {
+  "name": "glaive",
   "description": "Global Setting Avoidance.",
   "author": "Google",
   "repository": {"type": "git", "url": "git://github.com/google/glaive"},


### PR DESCRIPTION
I'd been putting off adding any fields that didn't actually make a difference yet, but at this point it's kind of silly to leave "name" out. I'm thinking maktaba will require an explicit name instead of just reusing the directory name so we can definitively resolve ambiguous names like "vim-FOO" and "FOO.vim", and especially when a plugin is installed through a symlink that changes the name (google/maktaba#31).
