### PR TITLE
Add ability to query flag values with ':Glaive <plugin>'

### DIFF
--- a/autoload/glaive.vim
+++ b/autoload/glaive.vim
@@ -189,3 +189,11 @@ function! glaive#GetPlugin(plugin) abort
   " If we're still here, we can't find the plugin.
   throw maktaba#error#NotFound('Plugin %s', a:plugin)
 endfunction
+
+function! glaive#PrintCurrentConfiguration(plugin) abort
+  echomsg 'Flags for ' . a:plugin.name . ':'
+  let l:flag_names = sort(keys(a:plugin.flags))
+  for l:name in l:flag_names
+    echomsg l:name . ': ' . string(a:plugin.flags[l:name].Get())
+  endfor
+endfunction

--- a/plugin/commands.vim
+++ b/plugin/commands.vim
@@ -25,6 +25,10 @@ function! s:Glaive(args) abort
     call maktaba#error#Shout(v:exception)
     return
   endtry
+  if l:operations is# ''
+    call glaive#PrintCurrentConfiguration(l:plugin)
+    return
+  endif
   try
     call glaive#Configure(l:plugin, l:operations)
   catch /ERROR(\(BadValue\|WrongType\|NotFound\)):/
@@ -51,6 +55,9 @@ endfunction
 "   " not recommended).
 "   :Glaive my!plugin flag
 " <
+"
+" If no [operation]s are given, the current value of all flags in {plugin} is
+" printed.
 "
 " Each [operation] may be in any of the following forms. They should be
 " separated by whitespace. The syntax for updating settings is as follows:


### PR DESCRIPTION
This adds only the ability to get the values of all a plugin's flags by ':Glaive <plugin>' without any flag names. I didn't attempt to add the ability to query individual flags. TBH, I'm not sure whether the logic of finding, e.g., a '?' in the setting string belongs in Glaive or Maktaba.
