### PR TITLE
Enable neovim mode tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,25 @@
 language: generic
+env:
+  matrix:
+    - CI_TARGET=vim
+    - CI_TARGET=neovim VROOM_ARGS=--neovim
 before_script:
-  - wget https://github.com/google/vroom/releases/download/v0.11.0/vroom_0.11.0-1_all.deb
-  - sudo dpkg -i vroom_0.11.0-1_all.deb
-  - sudo apt-get install vim-gnome
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - sudo apt-get install python3-dev
+  - if [ $CI_TARGET = vim ]; then
+      sudo apt-get install vim-gnome &&
+      # Vroom's vim mode currently requires a running X server.
+      export DISPLAY=:99.0 &&
+      sh -e /etc/init.d/xvfb start;
+    elif [ $CI_TARGET = neovim ]; then
+      # Install neovim.
+      eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64" &&
+      # Install pip and use it to install neovim python-client.
+      wget https://bootstrap.pypa.io/get-pip.py &&
+      sudo python3 get-pip.py --allow-external sudo &&
+      sudo pip3 install neovim;
+    fi
+  - wget https://github.com/google/vroom/releases/download/v0.12.0/vroom_0.12.0-1_all.deb
+  - sudo dpkg -i ./vroom_0.12.0-1_all.deb
   - git clone https://github.com/google/vim-maktaba.git ../maktaba/
 script:
-  - vroom --crawl ./vroom/
+  - vroom $VROOM_ARGS --crawl ./vroom/


### PR DESCRIPTION
Adds a Travis CI job configuration to run vroom in neovim mode on Glaive.

This will also serve as the basis for the recommended Travis CI configuration for neovim mode to be added to the vroom documentation (google/vroom#66). It demonstrates a few areas for improvement like the hard-coded vroom version number and awkward syntax for multiple Travis CI job configurations until Travis CI supports multiple jobs natively.
