### PR TITLE
Fix typo: sport -> support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ using the flag API can be configured by glaive.
 [Maktaba](http://github.com/google/vim-maktaba) is a vimscript library for
 plugin authors. It handles parsing the setting syntax, looking up the plugins,
 and applying the settings. Glaive itself is merely a thin wrapper around the
-hooks that maktaba provides: any plugin can sport a similar interface with
+hooks that maktaba provides: any plugin can support a similar interface with
 minimal effort. Plugin manager plugins in particular are encouraged to do so.
 
 For details, see the executable documentation in the `vroom/` directory or the

--- a/doc/glaive.txt
+++ b/doc/glaive.txt
@@ -20,7 +20,7 @@ For more details, see |:Glaive|.
 
 Note: Maktaba handles looking up the plugin, parsing the settings, and
 applying the settings. Glaive is a thin wrapper around maktaba's hooks. Other
-plugins can sport a similar interface with minimal effort. Plugin management
+plugins can support a similar interface with minimal effort. Plugin management
 plugins in particular are encouraged to do so.
 
 ==============================================================================

--- a/plugin/commands.vim
+++ b/plugin/commands.vim
@@ -11,7 +11,7 @@
 "
 " Note: Maktaba handles looking up the plugin, parsing the settings, and
 " applying the settings. Glaive is a thin wrapper around maktaba's hooks. Other
-" plugins can sport a similar interface with minimal effort. Plugin management
+" plugins can support a similar interface with minimal effort. Plugin management
 " plugins in particular are encouraged to do so.
 
 ""


### PR DESCRIPTION
I have read the documentation of the plugin and found this error. I fixed it in all the places I could find it.


I know it was advised to open issues before creating pull requests, but the change was so small it seemed redundant to me.
If you want me to open one (for documentation purposes or something like that), I will be happy to do it.