### PR TITLE
Tests: Fix neovim failures, use vroom 0.14.0, and update boilerplate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: generic
 env:
-  matrix:
+  global:
+    - VROOM_VERSION=0.14.0
+  jobs:
     # This Maktaba version should match the minimum required in bootstrap.vim.
     - CI_TARGET=vim MAKTABA_VERSION=1.1.1
     - CI_TARGET=vim MAKTABA_VERSION=master
@@ -13,18 +15,16 @@ before_script:
     elif [ $CI_TARGET = neovim ]; then
       eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64" &&
       wget https://bootstrap.pypa.io/get-pip.py &&
-      sudo python3 get-pip.py --allow-external sudo &&
+      sudo python3 get-pip.py &&
       sudo pip3 install neovim;
     fi
-  - wget https://github.com/google/vroom/releases/download/v0.12.0/vroom_0.12.0-1_all.deb
-  - sudo dpkg -i ./vroom_0.12.0-1_all.deb
+  - wget https://github.com/google/vroom/releases/download/v${VROOM_VERSION}/vroom_${VROOM_VERSION}-1_all.deb
+  - sudo dpkg -i ./vroom_${VROOM_VERSION}-1_all.deb
   - git clone -b ${MAKTABA_VERSION} https://github.com/google/vim-maktaba.git ../maktaba/
 services:
   - xvfb
 script:
   - '[ $CI_TARGET = neovim ] && VROOM_ARGS="--neovim" || VROOM_ARGS=""'
   - vroom $VROOM_ARGS --crawl ./vroom/
-matrix:
+jobs:
   fast_finish: true
-  allow_failures:
-    - env: CI_TARGET=neovim MAKTABA_VERSION=master

--- a/vroom/autoinstall.vroom
+++ b/vroom/autoinstall.vroom
@@ -5,16 +5,12 @@ To see how, we start by installing Glaive. In order for these tests to work,
 maktaba MUST be in the same directory as Glaive. Given that's the case, let's
 get Glaive installed:
 
-  :set nocompatible
-  :let g:glaivedir = fnamemodify($VROOMFILE, ':p:h:h')
-  :let g:bootstrapfile = g:glaivedir . '/bootstrap.vim'
-  :execute 'source' g:bootstrapfile
+  :source $VROOMDIR/setupvroom.vim
 
 Now, assume that some plugin manager has added the 'fullplugin' plugin to the
 runtimepath somehow.
 
-  :let g:thisdir = fnamemodify($VROOMFILE, ':p:h')
-  :let g:path = maktaba#path#Join([g:thisdir, 'fakeplugins', 'fullplugin'])
+  :let g:path = maktaba#path#Join([$VROOMDIR, 'fakeplugins', 'fullplugin'])
   :call maktaba#rtp#Add(g:path)
 
 This plugin has NOT been installed by maktaba: it's on the runtimepath, but its

--- a/vroom/dicts.vroom
+++ b/vroom/dicts.vroom
@@ -3,15 +3,11 @@ introduction to glaive syntax.
 
 Install glaive:
 
-  :set nocompatible
-  :let g:glaivedir = fnamemodify($VROOMFILE, ':p:h:h')
-  :let g:bootstrapfile = g:glaivedir . '/bootstrap.vim'
-  :execute 'source' g:bootstrapfile
+  :source $VROOMDIR/setupvroom.vim
 
 Install a plugin:
 
-  :let g:thisdir = fnamemodify($VROOMFILE, ':p:h')
-  :let g:path = maktaba#path#Join([g:thisdir, 'fakeplugins', 'fullplugin'])
+  :let g:path = maktaba#path#Join([$VROOMDIR, 'fakeplugins', 'fullplugin'])
   :let g:plugin = maktaba#plugin#Install(g:path)
 
 Define a dict flag:

--- a/vroom/floats.vroom
+++ b/vroom/floats.vroom
@@ -3,15 +3,11 @@ introduction to glaive syntax.
 
 Install glaive:
 
-  :set nocompatible
-  :let g:glaivedir = fnamemodify($VROOMFILE, ':p:h:h')
-  :let g:bootstrapfile = g:glaivedir . '/bootstrap.vim'
-  :execute 'source' g:bootstrapfile
+  :source $VROOMDIR/setupvroom.vim
 
 Install a plugin:
 
-  :let g:thisdir = fnamemodify($VROOMFILE, ':p:h')
-  :let g:path = maktaba#path#Join([g:thisdir, 'fakeplugins', 'fullplugin'])
+  :let g:path = maktaba#path#Join([$VROOMDIR, 'fakeplugins', 'fullplugin'])
   :let g:plugin = maktaba#plugin#Install(g:path)
 
 Define a float flag:

--- a/vroom/glaive.vroom
+++ b/vroom/glaive.vroom
@@ -37,18 +37,15 @@ And best of all, if your plugin uses maktaba flags, users have access to the
 pleasing manner. Let's have an example, shall we?
 
 In order for these tests to work, maktaba MUST be in the same directory as
-glaive. Given that that's the case, all we have to do is source the glaive
-bootstrap file.
+glaive. Given that that's the case, all we have to do is source the
+setupvroom.vim file, which bootstraps the glaive plugin and configures it to
+work properly under vroom.
 
-  :set nocompatible
-  :let g:glaivedir = fnamemodify($VROOMFILE, ':p:h:h')
-  :let g:bootstrapfile = g:glaivedir . '/bootstrap.vim'
-  :execute 'source' g:bootstrapfile
+  :source $VROOMDIR/setupvroom.vim
 
 Then we can install a plugin full of flags:
 
-  :let g:thisdir = fnamemodify($VROOMFILE, ':p:h')
-  :let g:path = maktaba#path#Join([g:thisdir, 'fakeplugins', 'fullplugin'])
+  :let g:path = maktaba#path#Join([$VROOMDIR, 'fakeplugins', 'fullplugin'])
   :let g:plugin = maktaba#plugin#Install(g:path)
 
 You can go browse through fakeplugins/fullplugin if you like: It defines

--- a/vroom/lists.vroom
+++ b/vroom/lists.vroom
@@ -3,15 +3,11 @@ introduction to glaive syntax.
 
 Install glaive:
 
-  :set nocompatible
-  :let g:glaivedir = fnamemodify($VROOMFILE, ':p:h:h')
-  :let g:bootstrapfile = g:glaivedir . '/bootstrap.vim'
-  :execute 'source' g:bootstrapfile
+  :source $VROOMDIR/setupvroom.vim
 
 Install a plugin:
 
-  :let g:thisdir = fnamemodify($VROOMFILE, ':p:h')
-  :let g:path = maktaba#path#Join([g:thisdir, 'fakeplugins', 'fullplugin'])
+  :let g:path = maktaba#path#Join([$VROOMDIR, 'fakeplugins', 'fullplugin'])
   :let g:plugin = maktaba#plugin#Install(g:path)
 
 Define a list flag:

--- a/vroom/numbers.vroom
+++ b/vroom/numbers.vroom
@@ -3,15 +3,11 @@ introduction to glaive syntax.
 
 Install glaive:
 
-  :set nocompatible
-  :let g:glaivedir = fnamemodify($VROOMFILE, ':p:h:h')
-  :let g:bootstrapfile = g:glaivedir . '/bootstrap.vim'
-  :execute 'source' g:bootstrapfile
+  :source $VROOMDIR/setupvroom.vim
 
 Install a plugin:
 
-  :let g:thisdir = fnamemodify($VROOMFILE, ':p:h')
-  :let g:path = maktaba#path#Join([g:thisdir, 'fakeplugins', 'fullplugin'])
+  :let g:path = maktaba#path#Join([$VROOMDIR, 'fakeplugins', 'fullplugin'])
   :let g:plugin = maktaba#plugin#Install(g:path)
 
 Define a numeric flag:

--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -1,0 +1,13 @@
+" This file is used from vroom scripts to bootstrap the codefmt plugin and
+" configure it to work properly under vroom.
+
+" Glaive does not support compatible mode.
+set nocompatible
+
+" Set cmdheight to avoid getting stuck at "Hit ENTER to continue" prompts,
+" particularly in neovim mode.
+set cmdheight=99
+
+" Install the glaive plugin and dependencies.
+let s:glaivedir = fnamemodify($VROOMFILE, ':p:h:h')
+execute 'source' s:glaivedir . '/bootstrap.vim'

--- a/vroom/strings.vroom
+++ b/vroom/strings.vroom
@@ -3,15 +3,11 @@ introduction to glaive syntax.
 
 Install glaive:
 
-  :set nocompatible
-  :let g:glaivedir = fnamemodify($VROOMFILE, ':p:h:h')
-  :let g:bootstrapfile = g:glaivedir . '/bootstrap.vim'
-  :execute 'source' g:bootstrapfile
+  :source $VROOMDIR/setupvroom.vim
 
 Install a plugin:
 
-  :let g:thisdir = fnamemodify($VROOMFILE, ':p:h')
-  :let g:path = maktaba#path#Join([g:thisdir, 'fakeplugins', 'fullplugin'])
+  :let g:path = maktaba#path#Join([$VROOMDIR, 'fakeplugins', 'fullplugin'])
   :let g:plugin = maktaba#plugin#Install(g:path)
 
 Define a string flag:


### PR DESCRIPTION
Specific changes:
  * Applies `set cmdheight=99` workaround to fix vroom neovim mode getting stuck.
  * Consolidates all vroom bootstrap commands to setupvroom.vim.
  * Fixes get-pip errors in .travis.yml, removes allow_failures, and renames legacy "matrix" field to "jobs".
  * Updates to use vroom 0.14.0 and make use of $VROOMDIR.